### PR TITLE
fix: replace deprecated pd.np usage in Tesco scraper

### DIFF
--- a/Scrape_Tesco.py
+++ b/Scrape_Tesco.py
@@ -19,8 +19,7 @@ import requests
 
 stuff_heads=['Name','Price','PreviousPrice','Offer']
 strip_previous_price = re.compile('(was)\s+\d+\.\d+', re.IGNORECASE)
-#df = pd.DataFrame()
-df = pd.DataFrame(pd.np.empty((0, 4)))    
+df = pd.DataFrame(columns=stuff_heads)
 nao = 0
 incrementor = 20
 bases=['https://www.tesco.ie/groceries/product/browse/default.aspx?N=4294531818&Ne=4294954028&Nao=',
@@ -93,9 +92,6 @@ for base in bases:
         df = df.append(data,ignore_index=True)
         
         nao = incrementor + nao
-
-
-df.columns = stuff_heads
 
 
 try:


### PR DESCRIPTION
## Summary
- avoid pandas AttributeError by initializing dataframe with column names
- drop redundant column assignment

## Testing
- `python -m py_compile Scrape_Tesco.py`


------
https://chatgpt.com/codex/tasks/task_e_689eadf7ebdc8330aa75b25f919a6fe1